### PR TITLE
Change '\TemplateName' to '\AcroTemplateName'

### DIFF
--- a/code/acro.sty
+++ b/code/acro.sty
@@ -656,7 +656,7 @@
     \clist_map_inline:nn {#1}
       {
         \acro_package_if_loaded:nF {##1}
-          { \msg_error:nnen {acro} {package-needed} { \TemplateName } {##1} }
+          { \msg_error:nnen {acro} {package-needed} { \AcroTemplateName } {##1} }
       }
   }
 
@@ -921,7 +921,7 @@
   { \acro_print_pages:enn { \AcronymID } {#1} {#2} }
 
 \NewDocumentCommand \acronopagerange {}
-  { \acro_no_page_ranges:e { \TemplateName } }
+  { \acro_no_page_ranges:e { \AcroTemplateName } }
 
 \NewDocumentCommand \acropagefill {}
   { \acro_if_pages:eT  { \AcronymID } { \tl_use:N \l__acro_pages_fill_tl } }


### PR DESCRIPTION
There appears to be a typo where \AcroTemplateName is incorrectly called \TemplateName in two places. If this is intentional please let me know. I modified these lines and it solved the issues I had with using the toc list format ([here is someone else with the same error](https://tex.stackexchange.com/questions/561791/acro-package-list-same-style-as-table-of-contents)).