### PR TITLE
Additional heading templates for KOMA-Script

### DIFF
--- a/code/acro.definitions.code.tex
+++ b/code/acro.definitions.code.tex
@@ -168,6 +168,8 @@
   {
     \NewAcroTemplate[heading] {addsec}
       { \addsec { \acrolistname } }
+    \NewAcroTemplate[heading] {addsec*}
+      { \addsec* { \acrolistname } }
   }
   
 \cs_if_exist:NT \chapter
@@ -180,6 +182,8 @@
       {
         \NewAcroTemplate[heading] {addchap}
         { \addchap { \acrolistname } }
+        \NewAcroTemplate[heading] {addchap*}
+        { \addchap* { \acrolistname } }
       }
   }
 

--- a/code/acro.interface.code.tex
+++ b/code/acro.interface.code.tex
@@ -149,7 +149,7 @@
 % declaring acronyms in the document body does not work,
 % cf. https://tex.stackexchange.com/q/568856/
 % so lets prevent people from doing so:
-\@onlypreamble \NewDocumentCommand
+\@onlypreamble \DeclareAcronym
 
 \NewDocumentCommand \DeclareAcroEnding {mmm}
   { \acro_declare_ending:nnn {#1} {#2} {#3} }

--- a/code/acro.list.code.tex
+++ b/code/acro.list.code.tex
@@ -177,8 +177,8 @@
 \acro_if_komascript:TF
   {
     \cs_if_exist:NTF \chapter
-      { \keys_set:nn {acro/list}{ heading = addchap } }
-      { \keys_set:nn {acro/list}{ heading = addsec } }
+      { \keys_set:nn {acro/list}{ heading = addchap* } }
+      { \keys_set:nn {acro/list}{ heading = addsec* } }
   }
   {
     \cs_if_exist:NTF \chapter

--- a/doc/acro-manual.tex
+++ b/doc/acro-manual.tex
@@ -1931,8 +1931,13 @@ to defines own such objects:
   \tmpl{addchap}
     Only defined in a \KOMAScript\ class and if \cs*{chapter} is defined. Uses
     \cs*{addchap} for the heading.
+  \tmpl{addchap*}
+    Only defined in a \KOMAScript\ class and if \cs*{chapter} is defined. Uses
+    \cs*{addchap*} for the heading.
   \tmpl{addsec}
     Only defined in a \KOMAScript\ class. Uses \cs*{addsec} for the heading.
+  \tmpl{addsec*}
+    Only defined in a \KOMAScript\ class. Uses \cs*{addsec*} for the heading.
   \tmpl{chapter}
     Only defined if \cs*{chapter} is defined. Uses \cs*{chapter} for the heading.
   \tmpl{chapter*}


### PR DESCRIPTION
KOMA-Script also provides `\addchap*` and `\addsec*` in addition to `\addchap` and `\addsec`, which do not create an entry in the table of contents and should therefore be used by default as an equivalent to the standard classes for consistency.