### PR TITLE
Change `\capitalisewords` to `\ecapitalisewords` in the documentation

### DIFF
--- a/doc/acro-manual.tex
+++ b/doc/acro-manual.tex
@@ -1368,7 +1368,7 @@ There are a number of options to control the uppercasing behavior:
     All of the above options just choose the right command using this option
     internally. This means you can choose a different behavior altogether by
     setting this option to something else.  For example you could use
-    \cs*{capitalisewords} from the package
+    \cs*{ecapitalisewords} from the package
     \pkg{mfirstuc}~\cite{pkg:mfirstuc}. The command needs to have one
     mandatory argument.
 \end{options}


### PR DESCRIPTION
I tried to have title casing for a command and followed the suggestion in the documentation to use `\capitalisewords` from `mfirstuc`. However, it doesn't work as expected, as it doesn't change anything. Some example I found in issue https://github.com/cgnieder/acro/issues/86#issuecomment-596238533 also does not work (anymore?).

However, after thinking and fiddling around, I saw that `mfirstuc` also has a command `\ecapitalisewords` which expands the provided argument before capitalizing it. And it actually works. Thus, to save future readers the hassle of having to find it out on their own, I propose to change the command referenced in the documentation to `\ecapitalisewords`.